### PR TITLE
Use findlib to decide the install directory

### DIFF
--- a/src/META
+++ b/src/META
@@ -7,7 +7,6 @@ requires(toploop) = "num.core,num-top"
 version = "1.0"
 description = "Arbitrary-precision rational arithmetic"
 package "core" (
-  directory = "^"
   version = "1.0"
   browse_interfaces = ""
   archive(byte) = "nums.cma"

--- a/src/Makefile
+++ b/src/Makefile
@@ -83,10 +83,10 @@ endif
 TOINSTALL_STUBS=dllnums.$(SO)
 
 install:
-	$(OCAMLFIND) install num META
-	$(INSTALL_DATA) $(TOINSTALL) $(STDLIBDIR)
+	$(OCAMLFIND) install num META $(TOINSTALL)
 ifeq "$(SUPPORTS_SHARED_LIBRARIES)" "true"
-	$(INSTALL_DLL) $(TOINSTALL_STUBS) $(STDLIBDIR)/stublibs
+	$(INSTALL_DLL) -d $(shell ocamlfind printconf destdir)/stublibs/
+	$(INSTALL_DLL) $(TOINSTALL_STUBS) $(shell ocamlfind printconf destdir)/stublibs/
 endif
 
 uninstall:


### PR DESCRIPTION
The `num` library is no longer part of the standard library. As such, the `install` target of the `Makefile` should not attempt to install it in the directory that is dedicated to the standard library.

This patch lets `findlib` decide where to install the `num` library, according to user settings, as any other library.

BTW, the removal of the `num` library should be marked as “breaking” in the release notes of OCaml 4.06.
