### PR TITLE
Proposal: install everything with ocamlfind

### DIFF
--- a/src/META
+++ b/src/META
@@ -1,13 +1,11 @@
 # This META is the one provided by findlib when the "num" library was
-# part of the core OCaml distribution.  For backward compatibility,
-# it installs into OCaml's standard library directory, not in a subdirectory
+# part of the core OCaml distribution.
 
 requires = "num.core"
 requires(toploop) = "num.core,num-top"
 version = "1.0"
 description = "Arbitrary-precision rational arithmetic"
 package "core" (
-  directory = "^"
   version = "1.0"
   browse_interfaces = ""
   archive(byte) = "nums.cma"

--- a/src/Makefile
+++ b/src/Makefile
@@ -84,18 +84,13 @@ endif
 TOINSTALL_STUBS=dllnums$(EXT_DLL)
 
 install:
-	$(OCAMLFIND) install num META
-	$(INSTALL_DATA) $(TOINSTALL) $(STDLIBDIR)
 ifeq "$(SUPPORTS_SHARED_LIBRARIES)" "true"
-	$(INSTALL_DIR) $(STDLIBDIR)/stublibs
-	$(INSTALL_DLL) $(TOINSTALL_STUBS) $(STDLIBDIR)/stublibs
+	$(OCAMLFIND) install num META $(TOINSTALL) $(TOINSTALL_STUBS)
+else
+	$(OCAMLFIND) install num META $(TOINSTALL)
 endif
 
 uninstall:
-	cd $(STDLIBDIR) && rm -f $(TOINSTALL)
-ifeq "$(SUPPORTS_SHARED_LIBRARIES)" "true"
-	cd $(STDLIBDIR)/stublibs && rm -f $(TOINSTALL_STUBS) 
-endif
 	$(OCAMLFIND) remove num
 
 clean:


### PR DESCRIPTION
Previously the `META` file was installed with `ocamlfind install` but the binary artifacts were installed directly in the `STDLIBDIR`. If using a system installation of OCaml (e.g. in `/usr/local/`) then we would install the `META` file in the opam root, but the artifacts outside (e.g. in `/usr/local/lib/ocaml`). On macOS with homebrew OCaml 4.06 it occasionally fails in the following way:

- `opam init`
- `opam install num`
  - `num` depends on `ocamlfind`. The [ocamlfind configure script](https://github.com/ocaml/opam-repository/blob/master/packages/ocamlfind/ocamlfind.1.7.3/files/check-num-in-sitelib.patch)  looks for a `num.cmi` in the `STDLIBDIR`. The intention is to supply a `META` file for libraries which are distributed with the compiler. Since it doesn't find a `num.cmi` it doesn't generate a `META` file. The `opam install num` succeeds as expected.

- `rm -rf .opam`
  - at this point `num.cmi` exists in `STDLIBDIR`, left over from the previous installation

- `opam init`
- `opam install num`
  - The `ocamlfind` `configure` script detects a `num.cmi` in the `STDLIBDIR` and assumes that the compiler has `num` included. It therefore installs a `META` file for it. Unfortunately the `opam install num` runs `ocamlfind install num` which fails since `num` is already installed. The `make uninstall` cleans up the `STDLIBDIR` so the next attempt would succeed (-- this was slightly confusing)

This patch installs all the artifacts with `ocamlfind` into the opam root. This is more like a normal OCaml library but is observably different to before, where care was taken to install the library into the `STDLIBDIR` to hide the difference between OCaml < 4.06 with `num` built-in and OCaml 4.06+ with `num` as an external package.

This would fix [ocaml/opam-repository#10857]

A workaround for the bug is to run the command again, since the cleanup steps from the failed install ensure the next attempt does succeed.

Another workaround is to not use the system compiler with `opam` but to always compile yourself a custom compiler (which is often desirable for other reasons...)

Signed-off-by: David Scott <dave@recoil.org>