### PR TITLE
Provide findlib-install target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 *.cmx[as]
 *.cmti
 *.annot
+src/META

--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,4 @@
+- GPR#6: provide findlib-install target to install everything using ocamlfind
 - Issue#3: make sur the stublibs/ directory exists before installing DLLs 
   inside it.
 - Issue#4: wrong DLL file names for Win32 ports, causing errors at

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,16 @@ install:
 	$(MAKE) -C src install
 	$(MAKE) -C toplevel install
 
+findlib-install:
+	$(MAKE) -C src findlib-install
+	$(MAKE) -C toplevel install
+
 uninstall:
 	$(MAKE) -C src uninstall
 	$(MAKE) -C toplevel uninstall
 
-.PHONY: all test clean install uninstall
+findlib-uninstall:
+	$(MAKE) -C src findlib-uninstall
+	$(MAKE) -C toplevel uninstall
+
+.PHONY: all test clean install uninstall findlib-install findlib-uninstall

--- a/src/META.in
+++ b/src/META.in
@@ -1,6 +1,8 @@
 # This META is the one provided by findlib when the "num" library was
 # part of the core OCaml distribution.  For backward compatibility,
-# it installs into OCaml's standard library directory, not in a subdirectory
+# it is installed into OCaml's standard library directory. If the
+# directory line below is removed, then it's installed in a
+# subdirectory, as normal for a findlib package.
 
 requires = "num.core"
 requires(toploop) = "num.core,num-top"

--- a/src/Makefile
+++ b/src/Makefile
@@ -81,22 +81,35 @@ endif
 ifeq "$(NATDYNLINK)" "true"
 TOINSTALL+=nums.cmxs
 endif
+ifeq "$(SUPPORTS_SHARED_LIBRARIES)" "true"
 TOINSTALL_STUBS=dllnums$(EXT_DLL)
+else
+TOINSTALL_STUBS=
+endif
 
 install:
+	cp META.in META
 	$(OCAMLFIND) install num META
+	rm -f META
 	$(INSTALL_DATA) $(TOINSTALL) $(STDLIBDIR)
 ifeq "$(SUPPORTS_SHARED_LIBRARIES)" "true"
 	$(INSTALL_DIR) $(STDLIBDIR)/stublibs
 	$(INSTALL_DLL) $(TOINSTALL_STUBS) $(STDLIBDIR)/stublibs
 endif
 
-uninstall:
+findlib-install:
+	grep -Fv '^' META.in > META
+	$(OCAMLFIND) install num META $(TOINSTALL) $(TOINSTALL_STUBS)
+	rm -f META
+
+findlib-uninstall:
+	$(OCAMLFIND) remove num
+
+uninstall: findlib-uninstall
 	cd $(STDLIBDIR) && rm -f $(TOINSTALL)
 ifeq "$(SUPPORTS_SHARED_LIBRARIES)" "true"
 	cd $(STDLIBDIR)/stublibs && rm -f $(TOINSTALL_STUBS) 
 endif
-	$(OCAMLFIND) remove num
 
 clean:
 	rm -f *.cm[ioxta] *.cmx[as] *.cmti *.$(O) *.$(A) *$(EXT_DLL)


### PR DESCRIPTION
See also discussions in https://github.com/ocaml/opam-repository/issues/10857 and #5.

This is an adaptation of #5 providing a separate `findlib-install` target which the opam `num` package can use for system switches.

Not installing things in `/usr/local/lib/ocaml` in an opam system switch is of course an opam packaging concern, but it seems better to me to control the process here in `num`'s repository and have it that the packaging concern is running `make findlib-install` if appropriate.

In future, we could change the `install` target to be the same as `findlib-install`.

This patch is presently being applied to 1.0 and 1.1 in https://github.com/ocaml/opam-repository/pull/11207