### PR TITLE
Small changes to fix compatibility with jsoo

### DIFF
--- a/src/int_misc.ml
+++ b/src/int_misc.ml
@@ -26,7 +26,7 @@ let num_bits_int n = num_bits_int_aux (abs n);;
 
 let sign_int i = if i = 0 then 0 else if i > 0 then 1 else -1;;
 
-let length_of_int = Sys.word_size - 2;;
+let length_of_int = Sys.int_size - 1;;
 
 let monster_int = 1 lsl length_of_int;;
 let biggest_int = monster_int - 1;;

--- a/src/nat.ml
+++ b/src/nat.ml
@@ -235,9 +235,9 @@ let sqrt_nat rad off len =
     shift_cand is word_size - nbb *)
  let shift_cand =
    ((num_leading_zero_bits_in_digit rad (len-1)) +
-     Sys.word_size * len_parity) / 2 in
+     length_of_digit * len_parity) / 2 in
  (* All radicand bits are zeroed, we give back 0. *)
- if shift_cand = Sys.word_size then cand else
+ if shift_cand = length_of_digit then cand else
  begin
   complement_nat cand 0 cand_len;
   shift_right_nat cand 0 1 a_1 0 shift_cand;

--- a/test/test.ml
+++ b/test/test.ml
@@ -82,7 +82,7 @@ let eq_int32 (i: int32) (j: int32) = (i = j);;
 let eq_int64 (i: int64) (j: int64) = (i = j);;
 let eq_float (x: float) (y: float) = Pervasives.compare x y = 0;;
 
-let sixtyfour = (1 lsl 31) <> 0;;
+let sixtyfour = Sys.int_size > 32
 
 let rec gcd_int i1 i2 =
   if i2 = 0 then abs i1 else gcd_int i2 (i1 mod i2);;
@@ -94,7 +94,7 @@ let num_bits_int n = num_bits_int_aux (abs n);;
 
 let sign_int i = if i = 0 then 0 else if i > 0 then 1 else -1;;
 
-let length_of_int = Sys.word_size - 2;;
+let length_of_int = Sys.int_size - 1;;
 
 let monster_int = 1 lsl length_of_int;;
 let biggest_int = monster_int - 1;;

--- a/test/test_big_ints.ml
+++ b/test/test_big_ints.ml
@@ -456,7 +456,7 @@ test 2
 eq_big_int (big_int_of_nat (power_base_int 10 8), big_int_of_int 100000000)
 ;;
 test 3
-eq_big_int (big_int_of_nat (power_base_int 2 (length_of_int + 2)),
+eq_big_int (big_int_of_nat (power_base_int 2 (Nat.length_of_digit)),
             big_int_of_nat (let nat = make_nat 2 in
                               set_digit_nat nat 1 1;
                               nat))


### PR DESCRIPTION
Theses changes, together with https://github.com/ocsigen/js_of_ocaml/pull/889, should be enough to have the tests pass when compiled to JavaScript with js_of_ocaml.

Note that theses changes should not affect the semantic in native or bytecode.   