### PR TITLE
CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,10 @@ jobs:
         ocaml-version:
           - 4.06.1
           - 4.12.0
-          - 4.13.0+trunk
+          - 4.12.0+options
+        exclude:
+          - os: windows-latest
+            ocaml-version: 4.12.0+options
 
     runs-on: ${{ matrix.os }}
 
@@ -25,32 +28,37 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set-up OCaml ${{ matrix.ocaml-version }}
-        id: ocaml
         uses: avsm/setup-ocaml@v1
         with:
           ocaml-version: ${{ matrix.ocaml-version }}
-        continue-on-error: ${{ contains(matrix.ocaml-version, '+trunk') }}
+
+      - name: Switch to trunk if necessary
+        id: ocaml
+        run: |-
+          opam switch create trunk --repos=default,beta=git+https://github.com/ocaml/ocaml-beta-repository.git ocaml-variants.4.13.0+trunk
+        continue-on-error: true
+        if: ${{ contains(matrix.ocaml-version, '+options') }}
 
       # Dune (may fail with trunk)
       - name: Install dune, if possible
         id: dune
         run: opam install dune
-        if: steps.ocaml.outcome == 'success'
-        continue-on-error: ${{ contains(matrix.ocaml-version, '+trunk') }}
+        if: steps.ocaml.outcome == 'success' || steps.ocaml.outcome == 'skipped'
+        continue-on-error: ${{ contains(matrix.ocaml-version, '+options') }}
 
       # Dependencies
       - run: opam install . --deps-only --with-doc --with-test
-        if: steps.ocaml.outcome == 'success'
+        if: steps.ocaml.outcome == 'success' || steps.ocaml.outcome == 'skipped'
       - run: opam pin add num . --no-action
-        if: steps.ocaml.outcome == 'success'
+        if: steps.ocaml.outcome == 'success' || steps.ocaml.outcome == 'skipped'
 
       # Check building with make
       - run: opam exec -- make
-        if: steps.ocaml.outcome == 'success'
+        if: steps.ocaml.outcome == 'success' || steps.ocaml.outcome == 'skipped'
       - run: opam exec -- make test
-        if: steps.ocaml.outcome == 'success'
+        if: steps.ocaml.outcome == 'success' || steps.ocaml.outcome == 'skipped'
       - run: opam exec -- make clean
-        if: steps.ocaml.outcome == 'success'
+        if: steps.ocaml.outcome == 'success' || steps.ocaml.outcome == 'skipped'
 
       # Check building with dune
       - run: opam exec -- dune build @install
@@ -62,4 +70,4 @@ jobs:
 
       # Check installing with opam
       - run: opam install num
-        if: steps.ocaml.outcome == 'success'
+        if: steps.ocaml.outcome == 'success' || steps.ocaml.outcome == 'skipped'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      # Test Linux, macOS and Windows with the oldest and newest supported OCaml
+      # and trunk.
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
+        ocaml-version:
+          - 4.06.1
+          - 4.12.0
+          - 4.13.0+trunk
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set-up OCaml ${{ matrix.ocaml-version }}
+        id: ocaml
+        uses: avsm/setup-ocaml@v1
+        with:
+          ocaml-version: ${{ matrix.ocaml-version }}
+        continue-on-error: ${{ contains(matrix.ocaml-version, '+trunk') }}
+
+      # Dune (may fail with trunk)
+      - name: Install dune, if possible
+        id: dune
+        run: opam install dune
+        if: steps.ocaml.outcome == 'success'
+        continue-on-error: ${{ contains(matrix.ocaml-version, '+trunk') }}
+
+      # Dependencies
+      - run: opam install . --deps-only --with-doc --with-test
+        if: steps.ocaml.outcome == 'success'
+      - run: opam pin add num . --no-action
+        if: steps.ocaml.outcome == 'success'
+
+      # Check building with make
+      - run: opam exec -- make
+        if: steps.ocaml.outcome == 'success'
+      - run: opam exec -- make test
+        if: steps.ocaml.outcome == 'success'
+      - run: opam exec -- make clean
+        if: steps.ocaml.outcome == 'success'
+
+      # Check building with dune
+      - run: opam exec -- dune build @install
+        if: steps.dune.outcome == 'success'
+      - run: opam exec -- dune runtest
+        if: steps.dune.outcome == 'success'
+      - run: opam exec -- dune clean
+        if: steps.dune.outcome == 'success'
+
+      # Check installing with opam
+      - run: opam install num
+        if: steps.ocaml.outcome == 'success'

--- a/num.opam
+++ b/num.opam
@@ -12,6 +12,7 @@ bug-reports: "https://github.com/ocaml/num/issues"
 dev-repo: "git+https://github.com/ocaml/num.git"
 build: [
   [make]
+  [make "test"] {with-test}
 ]
 install: [
   make

--- a/test/dune
+++ b/test/dune
@@ -1,7 +1,16 @@
 (alias
   (name runtest)
-  (action (progn (run %{dep:test.bc}) (run %{dep:test.exe}))))
+  (action (progn (run %{dep:driver.bc}) (run %{dep:driver.exe}))))
+
+(library
+  (name test_lib)
+  (modules test test_nats test_big_ints test_ratios test_nums test_io end_test)
+  (libraries num))
 
 (executable
-  (name test)
-  (libraries num))
+  (name driver)
+  (modules driver)
+  (flags -linkall)
+  (libraries test_lib))
+
+(rule (with-stdout-to driver.ml (echo "")))


### PR DESCRIPTION
Two minor updates to the testsuite: `opam install num --with-test` will now run the testsuite and `test/dune` was broken (it didn't actually run anything).

I've also added a trivial CI workflow based on **@‍avsm**'s setup-ocaml. It tests 4.06.1 (the oldest supported version), 4.12.0 (the current version) and trunk (at present, not on Windows, because there's no package for trunk in **@‍fdopen**'s repository).

setup-ocaml doesn't let you specify additional repositories, so while it's on opam 2.0 it can't install `ocaml-variants.4.13.0+trunk` directly. There's a workaround commit for this, so the "4.12.0+options" matrix item is in fact "4.13.0+trunk". This can be reverted when setup-ocaml switches to opam 2.1, as `ocaml-variants.4.13.0+trunk` can be installed directly then without extra repositories.

The workflow succeeds if `trunk` itself is broken and also skips testing the Dune files if dune doesn't build with trunk (which is true at the moment). Released compilers must succeed at all tests (and I've tested that the workflow does that).