### PR TITLE
fix: update dune and fix deps

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,1 +1,1 @@
-(lang dune 1.10)
+(lang dune 2.0)

--- a/src/dune
+++ b/src/dune
@@ -11,8 +11,11 @@
   (public_name num.core)
   (wrapped false)
   (modules arith_flags arith_status big_int int_misc nat num ratio)
-  (c_names nat_stubs bng bng_generic)
-  (c_flags "-DBNG_ARCH_%{architecture}")
+  (foreign_stubs
+   (language c)
+   (names nat_stubs bng bng_generic)
+   (extra_deps (glob_files *.c))
+   (flags "-DBNG_ARCH_%{architecture}"))
   (flags -w +a-4-9-41-42-44-45-48 -warn-error +A -bin-annot -g -safe-string -strict-sequence -strict-formats))
 
 (rule

--- a/src/dune
+++ b/src/dune
@@ -13,12 +13,7 @@
   (modules arith_flags arith_status big_int int_misc nat num ratio)
   (foreign_stubs
    (language c)
-   (names nat_stubs bng bng_generic)
+   (names nat_stubs bng)
    (extra_deps (glob_files *.c))
    (flags "-DBNG_ARCH_%{architecture}"))
-  (flags -w +a-4-9-41-42-44-45-48 -warn-error +A -bin-annot -g -safe-string -strict-sequence -strict-formats))
-
-(rule
-  (targets bng_generic.c)
-  (deps bng_digit.c bng_amd64.c bng_arm64.c bng_ia32.c bng_ppc.c)
-  (action (run touch bng_generic.c)))
+  (flags -w +a-4-9-41-42-44-45-48 -warn-error +A -g -safe-string -strict-sequence -strict-formats))

--- a/test/dune
+++ b/test/dune
@@ -1,5 +1,5 @@
-(alias
-  (name runtest)
+(rule
+  (alias runtest)
   (action (progn (run %{dep:driver.bc}) (run %{dep:driver.exe}))))
 
 (library
@@ -11,6 +11,7 @@
   (name driver)
   (modules driver)
   (flags -linkall)
+  (modes (byte exe))
   (libraries test_lib))
 
 (rule (with-stdout-to driver.ml (echo "")))

--- a/test/dune
+++ b/test/dune
@@ -1,6 +1,10 @@
 (rule
-  (alias runtest)
-  (action (progn (run %{dep:driver.bc}) (run %{dep:driver.exe}))))
+ (alias runtest)
+ (action (run ./driver.exe)))
+
+(rule
+ (alias runtest)
+ (action (run ./driver.bc)))
 
 (library
   (name test_lib)


### PR DESCRIPTION
We need to specify dependencies on all source files that are used by the build. This include the sources that are `#include`ed by the stubs. Previous versions of dune executed the rules in a slightly different order which which made the rule for `bng_target.c` execute first and that copied the other source files.

Fix #26 

@TheLortex what's this rule:

```
(rule
  (targets bng_generic.c)
  (deps bng_digit.c bng_amd64.c bng_arm64.c bng_ia32.c bng_ppc.c)
  (action (run touch bng_generic.c)))
```

Isn't this just a complex way to do:

```
(rule (with-stdout-to bng_generic.c (echo "")))
```