### PR TITLE
Use `dune` when installing via OPAM

### DIFF
--- a/num.opam
+++ b/num.opam
@@ -11,17 +11,13 @@ homepage: "https://github.com/ocaml/num/"
 bug-reports: "https://github.com/ocaml/num/issues"
 dev-repo: "git+https://github.com/ocaml/num.git"
 build: [
-  [make]
-  [make "test"] {with-test}
-]
-install: [
-  make
-  "install" {!ocaml:preinstalled}
-  "findlib-install" {ocaml:preinstalled}
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.06.0"}
-  "ocamlfind" {build & >= "1.7.3"}
+  "dune" {>= "2.0.0"}
 ]
 conflicts: [ "base-num" ]
 synopsis:


### PR DESCRIPTION
This uses `dune` to build and install the generated artifacts when installed via OPAM using the default dune commands that the dune documentation suggests.

I am not sure this has been proposed before, I couldn't find anything in that regard.

Dune also supports a split between development mode and release mode where warnings are not fatal, hence:

Closes #19