### PR TITLE
Fix bytecode-only build for 4.12+

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -4,14 +4,14 @@ OCAMLDEP=ocamldep
 OCAMLMKLIB=ocamlmklib
 OCAMLFIND=ocamlfind
 OCAMLRUN=ocamlrun
-STDLIBDIR=$(shell $(OCAMLC) -where)
+STDLIBDIR:=$(shell $(OCAMLC) -where)
 VERSION=$(shell sed -ne 's/^ *version *: *"\([^"]*\)".*$$/\1/p' ../num.opam)
 
 INSTALL_DATA=install -m 644
 INSTALL_DLL=install
 INSTALL_DIR=install -d
 
-include $(shell $(OCAMLC) -where)/Makefile.config
+include $(STDLIBDIR)/Makefile.config
 
 ifeq "$(NATIVE_COMPILER)" ""
 # $(NATIVE_COMPILER) was added in 4.09: use $(ARCH) for 4.06-4.08

--- a/Makefile.common
+++ b/Makefile.common
@@ -1,0 +1,23 @@
+OCAMLC=ocamlc
+OCAMLOPT=ocamlopt
+OCAMLDEP=ocamldep
+OCAMLMKLIB=ocamlmklib
+OCAMLFIND=ocamlfind
+OCAMLRUN=ocamlrun
+STDLIBDIR=$(shell $(OCAMLC) -where)
+VERSION=$(shell sed -ne 's/^ *version *: *"\([^"]*\)".*$$/\1/p' ../num.opam)
+
+INSTALL_DATA=install -m 644
+INSTALL_DLL=install
+INSTALL_DIR=install -d
+
+include $(shell $(OCAMLC) -where)/Makefile.config
+
+ifeq "$(NATIVE_COMPILER)" ""
+# $(NATIVE_COMPILER) was added in 4.09: use $(ARCH) for 4.06-4.08
+ifeq "$(ARCH)" "none"
+NATIVE_COMPILER = false
+else
+NATIVE_COMPILER = true
+endif
+endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,24 +1,6 @@
-OCAMLC=ocamlc
-OCAMLOPT=ocamlopt
-OCAMLDEP=ocamldep
-OCAMLMKLIB=ocamlmklib
-OCAMLFIND=ocamlfind
-INSTALL_DATA=install -m 644
-INSTALL_DLL=install
-INSTALL_DIR=install -d
-STDLIBDIR=$(shell $(OCAMLC) -where)
+include ../Makefile.common
+
 DESTDIR ?=
-
-include $(STDLIBDIR)/Makefile.config
-
-ifeq "$(NATIVE_COMPILER)" ""
-# $(NATIVE_COMPILER) was added in 4.09: use $(ARCH) for 4.06-4.08
-ifeq "$(ARCH)" "none"
-NATIVE_COMPILER = false
-else
-NATIVE_COMPILER = true
-endif
-endif
 
 ifeq "$(filter i386 amd64 arm64 power,$(ARCH))" ""
 # Unsupported architecture
@@ -91,8 +73,6 @@ TOINSTALL_STUBS=dllnums$(EXT_DLL)
 else
 TOINSTALL_STUBS=
 endif
-
-VERSION=$(shell sed -ne 's/^ *version *: *"\([^"]*\)".*$$/\1/p' ../num.opam)
 
 install:
 	$(INSTALL_DIR) $(DESTDIR)$(STDLIBDIR)

--- a/src/Makefile
+++ b/src/Makefile
@@ -11,6 +11,15 @@ DESTDIR ?=
 
 include $(STDLIBDIR)/Makefile.config
 
+ifeq "$(NATIVE_COMPILER)" ""
+# $(NATIVE_COMPILER) was added in 4.09: use $(ARCH) for 4.06-4.08
+ifeq "$(ARCH)" "none"
+NATIVE_COMPILER = false
+else
+NATIVE_COMPILER = true
+endif
+endif
+
 ifeq "$(filter i386 amd64 arm64 power,$(ARCH))" ""
 # Unsupported architecture
 BNG_ARCH=generic
@@ -33,7 +42,7 @@ COBJS=bng.$(O) nat_stubs.$(O)
 
 all:: libnums.$(A) nums.cma
 
-ifneq "$(ARCH)" "none"
+ifeq "$(NATIVE_COMPILER)" "true"
 all:: nums.cmxa
 endif
 
@@ -71,7 +80,7 @@ nat_stubs.$(O): bng.h nat.h
 # is installed via findlib
 
 TOINSTALL=nums.cma libnums.$(A) $(CMIS) $(CMIS:.cmi=.mli) $(CMIS:.cmi=.cmti)
-ifneq "$(ARCH)" "none"
+ifeq "$(NATIVE_COMPILER)" "true"
 TOINSTALL+=nums.cmxa nums.$(A) $(CMXS)
 endif
 ifeq "$(NATDYNLINK)" "true"

--- a/test/Makefile
+++ b/test/Makefile
@@ -13,7 +13,7 @@ all:: test.byt
 	@echo "----- Testing in bytecode..."
 	$(OCAMLRUN) -I ../src ./test.byt
 
-ifneq "$(ARCH)" "none"
+ifeq "$(filter false,$(NATIVE_COMPILER))$(filter none,$(ARCH))" ""
 all:: test.exe
 	@echo "----- Testing in native code..."
 	./test.exe

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,8 +1,4 @@
-OCAMLC=ocamlc
-OCAMLOPT=ocamlopt
-OCAMLRUN=ocamlrun
-
-include $(shell $(OCAMLC) -where)/Makefile.config
+include ../Makefile.common
 
 CAMLCFLAGS=
 CAMLOPTFLAGS=$(CAMLCFLAGS)

--- a/test/Makefile
+++ b/test/Makefile
@@ -9,7 +9,7 @@ all:: test.byt
 	@echo "----- Testing in bytecode..."
 	$(OCAMLRUN) -I ../src ./test.byt
 
-ifeq "$(filter false,$(NATIVE_COMPILER))$(filter none,$(ARCH))" ""
+ifeq "$(NATIVE_COMPILER)" "true"
 all:: test.exe
 	@echo "----- Testing in native code..."
 	./test.exe

--- a/toplevel/Makefile
+++ b/toplevel/Makefile
@@ -1,6 +1,4 @@
-OCAMLC=ocamlc
-OCAMLDEP=ocamldep
-OCAMLFIND=ocamlfind
+include ../Makefile.common
 
 CAMLCFLAGS=-I ../src -I +compiler-libs \
            -w +a-4-9-41-42-44-45-48 -warn-error +A \
@@ -20,8 +18,6 @@ num_top.cma: $(CMOS)
 
 TOINSTALL=\
   num_top.cma num_top.cmi num_top_printers.cmi
-
-VERSION=$(shell sed -ne 's/^ *version *: *"\([^"]*\)".*$$/\1/p' ../num.opam)
 
 install:
 	sed -e 's/%%VERSION%%/$(VERSION)/g' META.in > META


### PR DESCRIPTION
I escaped the baking going on downstairs at home...

This should fix the problem on bytecode-only builds identified in https://github.com/ocaml/opam-repository/pull/22689. The build failure is caused by https://github.com/ocaml/ocaml/pull/10044, but in fact the compilation of `bng.o` in bytecode also ideally wants the correct value for `$(ARCH)`.

OCaml 4.09 introduced the `NATIVE_COMPILER` variable into `Makefile.config` - the fix I propose here is just to emulate that variable using `ARCH` if it's missing (which should apply for 4.06-4.08 incl.). It worked when pinned in the 4.12 Docker container mentioned in the attached opam-repository PR:

```Dockerfile
FROM ocaml/opam:debian-11-opam
ENV OPAMCONFIRMLEVEL=unsafe-yes
RUN opam-2.1 switch create 4.12 ocaml.4.12.1 ocaml-option-bytecode-only
RUN opam-2.1 pin add --switch=4.12 num git+https://github.com/dra27/num.git#fix-bytecode-only-build
```