### PR TITLE
nums.cmxs: set executable bit when installing with OPAM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,4 +59,4 @@ jobs:
         if: steps.dune.outcome == 'success'
 
       # Check installing with opam
-      - run: opam install num
+      - run: opam install --strict num

--- a/src/Makefile
+++ b/src/Makefile
@@ -116,9 +116,9 @@ TOINSTALL_NUM_TOP=num_top.cma $(addsuffix .cmi,$(MODULES_NUM_TOP))
 # lib_root section
 #   - num-top files (legacy and modern)
 #   - num artefacts to ocaml/ (legacy only)
-#   - dllnums.so to ocaml/stublibs/ (legacy only)
 # libexec_root section
 #   - nums.cmxs (legacy only)
+#   - dllnums.so to ocaml/stublibs/ (legacy only)
 # lib section:
 #   - num META file
 #   - num artefacts (modern only)
@@ -135,12 +135,10 @@ $(foreach file,$(TOINSTALL_NUM_TOP),
 ifeq "$(1)" "legacy"
 $(foreach file,$(TOINSTALL),
 	@echo '  "src/$(file)" {"ocaml/$(file)"}' >> $$@)
-ifneq "$(TOINSTALL_CMXS)" ""
+	@echo ']' >> $$@
 	@echo 'libexec_root: [' >> $$@
 $(foreach file,$(TOINSTALL_CMXS),
 	@echo '  "src/$(file)" {"ocaml/$(file)"}' >> $$@)
-	@echo ']' >> $$@
-endif
 $(foreach file,$(TOINSTALL_STUBS),
 	@echo '  "src/$(file)" {"ocaml/stublibs/$(file)"}' >> $$@)
 endif
@@ -151,12 +149,10 @@ ifeq "$(1)" "modern"
 $(foreach file,$(TOINSTALL),
 	@echo '  "src/$(file)"' >> $$@)
 	@echo ']' >> $$@
-ifneq "$(TOINSTALL_CMXS)" ""
 	@echo 'libexec: [' >> $$@
 $(foreach file,$(TOINSTALL_CMXS),
 	@echo '  "src/$(file)"' >> $$@)
 	@echo ']' >> $$@
-endif
 	@echo 'stublibs: [' >> $$@
 $(foreach file,$(TOINSTALL_STUBS),
 	@echo '  "src/$(file)"' >> $$@)
@@ -172,7 +168,10 @@ install: num-top-install
 	cp META.legacy META
 	$(OCAMLFIND) install num META
 	rm -f META
-	$(INSTALL_DATA) $(TOINSTALL) $(TOINSTALL_CMXS) $(DESTDIR)$(STDLIBDIR)
+	$(INSTALL_DATA) $(TOINSTALL) $(DESTDIR)$(STDLIBDIR)
+ifeq "$(NATDYNLINK)" "true"
+	$(INSTALL_DLL) $(TOINSTALL_CMXS) $(DESTDIR)$(STDLIBDIR)
+endif
 ifeq "$(SUPPORTS_SHARED_LIBRARIES)" "true"
 	$(INSTALL_DIR) $(DESTDIR)$(STDLIBDIR)/stublibs
 	$(INSTALL_DLL) $(TOINSTALL_STUBS) $(DESTDIR)$(STDLIBDIR)/stublibs

--- a/src/Makefile
+++ b/src/Makefile
@@ -101,7 +101,9 @@ ifeq "$(NATIVE_COMPILER)" "true"
 TOINSTALL+=nums.cmxa nums.$(A) $(CMXS)
 endif
 ifeq "$(NATDYNLINK)" "true"
-TOINSTALL+=nums.cmxs
+TOINSTALL_CMXS=nums.cmxs
+else
+TOINSTALL_CMXS=
 endif
 ifeq "$(SUPPORTS_SHARED_LIBRARIES)" "true"
 TOINSTALL_STUBS=dllnums$(EXT_DLL)
@@ -115,9 +117,13 @@ TOINSTALL_NUM_TOP=num_top.cma $(addsuffix .cmi,$(MODULES_NUM_TOP))
 #   - num-top files (legacy and modern)
 #   - num artefacts to ocaml/ (legacy only)
 #   - dllnums.so to ocaml/stublibs/ (legacy only)
+# libexec_root section
+#   - nums.cmxs (legacy only)
 # lib section:
 #   - num META file
 #   - num artefacts (modern only)
+# libexec section:
+#   - nums.cmxs (modern only)
 # stublibs section:
 #   - dllnums.so (modern only)
 define GENERATE_INSTALL_FILE
@@ -129,6 +135,12 @@ $(foreach file,$(TOINSTALL_NUM_TOP),
 ifeq "$(1)" "legacy"
 $(foreach file,$(TOINSTALL),
 	@echo '  "src/$(file)" {"ocaml/$(file)"}' >> $$@)
+ifneq "$(TOINSTALL_CMXS)" ""
+	@echo 'libexec_root: [' >> $$@
+$(foreach file,$(TOINSTALL_CMXS),
+	@echo '  "src/$(file)" {"ocaml/$(file)"}' >> $$@)
+	@echo ']' >> $$@
+endif
 $(foreach file,$(TOINSTALL_STUBS),
 	@echo '  "src/$(file)" {"ocaml/stublibs/$(file)"}' >> $$@)
 endif
@@ -139,6 +151,12 @@ ifeq "$(1)" "modern"
 $(foreach file,$(TOINSTALL),
 	@echo '  "src/$(file)"' >> $$@)
 	@echo ']' >> $$@
+ifneq "$(TOINSTALL_CMXS)" ""
+	@echo 'libexec: [' >> $$@
+$(foreach file,$(TOINSTALL_CMXS),
+	@echo '  "src/$(file)"' >> $$@)
+	@echo ']' >> $$@
+endif
 	@echo 'stublibs: [' >> $$@
 $(foreach file,$(TOINSTALL_STUBS),
 	@echo '  "src/$(file)"' >> $$@)
@@ -154,7 +172,7 @@ install: num-top-install
 	cp META.legacy META
 	$(OCAMLFIND) install num META
 	rm -f META
-	$(INSTALL_DATA) $(TOINSTALL) $(DESTDIR)$(STDLIBDIR)
+	$(INSTALL_DATA) $(TOINSTALL) $(TOINSTALL_CMXS) $(DESTDIR)$(STDLIBDIR)
 ifeq "$(SUPPORTS_SHARED_LIBRARIES)" "true"
 	$(INSTALL_DIR) $(DESTDIR)$(STDLIBDIR)/stublibs
 	$(INSTALL_DLL) $(TOINSTALL_STUBS) $(DESTDIR)$(STDLIBDIR)/stublibs
@@ -167,7 +185,7 @@ num-top-install:
 
 findlib-install: num-top-install
 	cp META.modern META
-	$(OCAMLFIND) install num META $(TOINSTALL) $(TOINSTALL_STUBS)
+	$(OCAMLFIND) install num META $(TOINSTALL) $(TOINSTALL_CMXS) $(TOINSTALL_STUBS)
 	rm -f META
 
 num-top-uninstall:
@@ -177,7 +195,7 @@ findlib-uninstall: num-top-uninstall
 	$(OCAMLFIND) remove num
 
 uninstall: findlib-uninstall
-	cd $(DESTDIR)$(STDLIBDIR) && rm -f $(TOINSTALL)
+	cd $(DESTDIR)$(STDLIBDIR) && rm -f $(TOINSTALL) $(TOINSTALL_CMXS)
 ifeq "$(SUPPORTS_SHARED_LIBRARIES)" "true"
 	cd $(DESTDIR)$(STDLIBDIR)/stublibs && rm -f $(TOINSTALL_STUBS)
 endif


### PR DESCRIPTION
Following the discussion in https://github.com/ocaml/ocaml/issues/12419, this PR adapts the installation procedure to set the executable bit of `nums.cmxs` (when native dynlinking is supported). Note that only the OPAM installation methods are adapted, the legacy (using `install` and `ocamlfind` are not adapted).

Assigning to @dra27 who introduced the use of `.install` files in #29.

Fixes #32.