### PR TITLE
Tweak the opam file

### DIFF
--- a/num.opam
+++ b/num.opam
@@ -11,7 +11,8 @@ homepage: "https://github.com/ocaml/num/"
 bug-reports: "https://github.com/ocaml/num/issues"
 dev-repo: "git+https://github.com/ocaml/num.git"
 build: [
-  [make "opam-legacy" {!ocaml:preinstalled} "opam-modern" {ocaml:preinstalled | ocaml:version >= "5.0.0~~"}]
+  [make "opam-legacy" {!ocaml:preinstalled & ocaml:version < "5.0.0~~"}
+        "opam-modern" {ocaml:preinstalled | ocaml:version >= "5.0.0~~"}]
   [make "test"] {with-test}
 ]
 depends: [


### PR DESCRIPTION
Spotted while testing #33 - the idea is that we build _either_ `opam-legacy`, which generates a `num.install` which puts the artefacts in the "traditional" pre-4.06 locations in the compiler distribution, just like the `install` target does, or we build `opam-modern`, which generates a `num.install` which puts the artefacts as a separate package, just the `findlib-install` target does. Accidentally, in the latter case, we'd end up with `make opam-legacy opam-modern` which was fine, but unnecessarily built two `num.install` files, with the (correct) second one overwriting the first.