### PR TITLE
Implement Nat.length_nat as an external primitive

### DIFF
--- a/src/nat.ml
+++ b/src/nat.ml
@@ -67,7 +67,7 @@ external lxor_digit_nat: nat -> int -> nat -> int -> unit = "lxor_digit_nat"
 external initialize_nat: unit -> unit = "initialize_nat"
 let _ = initialize_nat()
 
-let length_nat (n : nat) = Obj.size (Obj.repr n) - 1
+external length_nat : nat -> int = "length_nat" [@@noalloc]
 
 let length_of_digit = Sys.word_size;;
 

--- a/src/nat.mli
+++ b/src/nat.mli
@@ -30,7 +30,7 @@ external nth_digit_nat: nat -> int -> int = "nth_digit_nat"
 external set_digit_nat_native: nat -> int -> nativeint -> unit
                              = "set_digit_nat_native"
 external nth_digit_nat_native: nat -> int -> nativeint = "nth_digit_nat_native"
-val length_nat : nat -> int
+external length_nat : nat -> int = "length_nat" [@@noalloc]
 external num_digits_nat: nat -> int -> int -> int = "num_digits_nat"
 external num_leading_zero_bits_in_digit: nat -> int -> int
                                        = "num_leading_zero_bits_in_digit"


### PR DESCRIPTION
The current implementation of `length_nat` really depends on the representation of nats.
There is a hack to make it work with Js_of_ocaml, but it is not possible to do the same thing for Wasm_of_ocaml.
Implementing this function as an external primitive would resolve this issue and should not have much of a performance impact.