### PR TITLE
Fix CI failures on `opam install` test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,13 @@ jobs:
         ocaml-version:
           - 4.06.x
           - 4.14.x
-          - 5.0.x
+          - 5.1.x
           - ocaml-variants.5.2.0+trunk
         exclude:
           - os: windows-latest
             ocaml-version: ocaml-variants.5.2.0+trunk
           - os: windows-latest
-            ocaml-version: 5.0.x
+            ocaml-version: 5.1.x
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
         uses: ocaml/setup-ocaml@v2
         with:
           ocaml-compiler: ${{ matrix.ocaml-version }}
+          allow-prelease-opam: true
 
       # Dune (may fail with trunk)
       - name: Install dune, if possible

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
           - 4.06.x
           - 4.14.x
           - 5.0.x
-          - ocaml-variants.5.1.0+trunk
+          - ocaml-variants.5.2.0+trunk
         exclude:
           - os: windows-latest
-            ocaml-version: ocaml-variants.5.1.0+trunk
+            ocaml-version: ocaml-variants.5.2.0+trunk
           - os: windows-latest
             ocaml-version: 5.0.x
 


### PR DESCRIPTION
Allow pre-released opam to workaround `--strict` encountering an opam 2.2 flag. Can be removed after opam 2.2 itself is released.