### PR TITLE
Install to `lib`/`stublibs` in legacy mode as well

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,7 @@
 *.cmti
 *.annot
 src/META.top
-src/META.modern
-src/META.legacy
+src/META.num
 src/META
 src/num_top*.ml*
 test/test.byt

--- a/src/Makefile
+++ b/src/Makefile
@@ -121,11 +121,11 @@ TOINSTALL_NUM_TOP=num_top.cma $(addsuffix .cmi,$(MODULES_NUM_TOP))
 #   - dllnums.so to ocaml/stublibs/ (legacy only)
 # lib section:
 #   - num META file
-#   - num artefacts (modern only)
+#   - num artefacts
 # libexec section:
 #   - nums.cmxs (modern only)
 # stublibs section:
-#   - dllnums.so (modern only)
+#   - dllnums.so
 define GENERATE_INSTALL_FILE
 num-$1.install:
 	@echo 'lib_root: [' > $$@
@@ -145,7 +145,6 @@ endif
 	@echo ']' >> $$@
 	@echo 'lib: [' >> $$@
 	@echo '  "src/META.$(1)" {"META"}' >> $$@
-ifeq "$(1)" "modern"
 $(foreach file,$(TOINSTALL),
 	@echo '  "src/$(file)"' >> $$@)
 	@echo ']' >> $$@
@@ -156,7 +155,6 @@ $(foreach file,$(TOINSTALL_CMXS),
 	@echo 'stublibs: [' >> $$@
 $(foreach file,$(TOINSTALL_STUBS),
 	@echo '  "src/$(file)"' >> $$@)
-endif
 	@echo ']' >> $$@
 endef
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -114,7 +114,6 @@ TOINSTALL_NUM_TOP=num_top.cma $(addsuffix .cmi,$(MODULES_NUM_TOP))
 #   - num artefacts to ocaml/ (legacy only)
 # libexec_root section
 #   - nums.cmxs (legacy only)
-#   - dllnums.so to ocaml/stublibs/ (legacy only)
 # lib section:
 #   - num META file
 #   - num artefacts
@@ -135,8 +134,6 @@ $(foreach file,$(TOINSTALL),
 	@echo 'libexec_root: [' >> $$@
 $(foreach file,$(TOINSTALL_CMXS),
 	@echo '  "src/$(file)" {"ocaml/$(file)"}' >> $$@)
-$(foreach file,$(TOINSTALL_STUBS),
-	@echo '  "src/$(file)" {"ocaml/stublibs/$(file)"}' >> $$@)
 endif
 	@echo ']' >> $$@
 	@echo 'lib: [' >> $$@

--- a/src/Makefile
+++ b/src/Makefile
@@ -42,16 +42,12 @@ META.top: META.num-top.in
 	echo 'version = "$(VERSION)"' > $@
 	cat $^ >> $@
 
-META.%:
+META.modern:
 	@echo 'requires = "num.core"' > $@
 	@echo 'requires(toploop) = "num.core,num-top"' >> $@
 	@echo 'version = "$(VERSION)"' >> $@
 	@echo 'description = "Arbitrary-precision rational arithmetic"' >> $@
 	@echo 'package "core" (' >> $@
-# META.legacy installs num to the OCaml standard library directory so requires
-# the extra directory line. META.modern installs num as a standard findlib
-# package.
-	@echo '  directory = "^"' >> $(if $(*:legacy=),/dev/null,$@)
 	@echo '  version = "$(VERSION)"' >> $@
 	@echo '  browse_interfaces = ""' >> $@
 	@echo '  archive(byte) = "nums.cma"' >> $@
@@ -63,6 +59,9 @@ ifeq "$(NATDYNLINK)" "true"
 	@echo '  plugin(native) = "nums.cmxs"' >> $@
 endif
 	@echo ')' >> $@
+
+META.legacy: META.modern
+	cp $< $@
 
 libnums.$(A): $(COBJS)
 	$(OCAMLMKLIB) -oc nums $(COBJS)
@@ -144,7 +143,7 @@ $(foreach file,$(TOINSTALL_STUBS),
 endif
 	@echo ']' >> $$@
 	@echo 'lib: [' >> $$@
-	@echo '  "src/META.$(1)" {"META"}' >> $$@
+	@echo '  "src/META.modern" {"META"}' >> $$@
 $(foreach file,$(TOINSTALL),
 	@echo '  "src/$(file)"' >> $$@)
 	@echo ']' >> $$@

--- a/src/Makefile
+++ b/src/Makefile
@@ -27,7 +27,7 @@ SOURCES_NUM_TOP=\
   $(addsuffix .mli,$(MODULES_NUM_TOP)) $(addsuffix .ml,$(MODULES_NUM_TOP))
 CMOS_NUM_TOP=$(addsuffix .cmo,$(MODULES_NUM_TOP))
 
-all:: libnums.$(A) nums.cma num_top.cma META.legacy META.modern META.top \
+all:: libnums.$(A) nums.cma num_top.cma META.num META.top \
       num-legacy.install num-modern.install
 
 ifeq "$(NATIVE_COMPILER)" "true"
@@ -42,7 +42,7 @@ META.top: META.num-top.in
 	echo 'version = "$(VERSION)"' > $@
 	cat $^ >> $@
 
-META.modern:
+META.num:
 	@echo 'requires = "num.core"' > $@
 	@echo 'requires(toploop) = "num.core,num-top"' >> $@
 	@echo 'version = "$(VERSION)"' >> $@
@@ -59,9 +59,6 @@ ifeq "$(NATDYNLINK)" "true"
 	@echo '  plugin(native) = "nums.cmxs"' >> $@
 endif
 	@echo ')' >> $@
-
-META.legacy: META.modern
-	cp $< $@
 
 libnums.$(A): $(COBJS)
 	$(OCAMLMKLIB) -oc nums $(COBJS)
@@ -143,7 +140,7 @@ $(foreach file,$(TOINSTALL_STUBS),
 endif
 	@echo ']' >> $$@
 	@echo 'lib: [' >> $$@
-	@echo '  "src/META.modern" {"META"}' >> $$@
+	@echo '  "src/META.num" {"META"}' >> $$@
 $(foreach file,$(TOINSTALL),
 	@echo '  "src/$(file)"' >> $$@)
 	@echo ']' >> $$@
@@ -162,7 +159,7 @@ $(eval $(call GENERATE_INSTALL_FILE,modern))
 
 install: num-top-install
 	$(INSTALL_DIR) $(DESTDIR)$(STDLIBDIR)
-	cp META.legacy META
+	cp META.num META
 	$(OCAMLFIND) install num META
 	rm -f META
 	$(INSTALL_DATA) $(TOINSTALL) $(DESTDIR)$(STDLIBDIR)
@@ -180,7 +177,7 @@ num-top-install:
 	rm -f META
 
 findlib-install: num-top-install
-	cp META.modern META
+	cp META.num META
 	$(OCAMLFIND) install num META $(TOINSTALL) $(TOINSTALL_CMXS) $(TOINSTALL_STUBS)
 	rm -f META
 
@@ -198,7 +195,7 @@ endif
 
 clean:
 	rm -f *.cm[ioxta] *.cmx[as] *.cmti *.$(O) *.$(A) *$(EXT_DLL) \
-        META.top META.legacy META.modern $(SOURCES_NUM_TOP) \
+        META.top META.num $(SOURCES_NUM_TOP) \
         num-legacy.install num-modern.install
 
 $(SOURCES_NUM_TOP:num_=%): $(addprefix ../toplevel/,$(SOURCES_NUM_TOP))


### PR DESCRIPTION
This changes the `Makefile` slighty so that in the legacy mode the files will be installed into the package directory as well as into the stdlib.

This allows dune to install `num` outside of the compiler and still use num like a regular findlib package (with the `cmi`, `cma` etc in the package folder), while keeping it in the stdlib for packages that do not use findlib nor dune and just add `nums.cma` in their build.