### PR TITLE
CI updates (again)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,15 +14,10 @@ jobs:
           - ubuntu-latest
           - windows-latest
         ocaml-version:
-          - 4.06.x
-          - 4.14.x
-          - 5.2.x
-          - ocaml-variants.5.3.0+trunk
-        exclude:
-          - os: windows-latest
-            ocaml-version: ocaml-variants.5.2.0+trunk
-          - os: windows-latest
-            ocaml-version: 5.1.x
+          - "4.06"
+          - "4.14"
+          - "5.2"
+          - "ocaml-variants.5.3.0+trunk"
 
     runs-on: ${{ matrix.os }}
 
@@ -31,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set-up OCaml ${{ matrix.ocaml-version }}
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3.0.0-beta
         with:
           ocaml-compiler: ${{ matrix.ocaml-version }}
           allow-prerelease-opam: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,16 @@ jobs:
           - ubuntu-latest
           - windows-latest
         ocaml-version:
-          - "4.06"
           - "4.14"
           - "5.2"
           - "ocaml-variants.5.3.0+trunk"
-        exclude:
-          - os: windows-latest
+        include:
+          - os: ubuntu-latest
             ocaml-version: "4.06"
+          - os: macos-13
+            ocaml-version: "4.06"
+          - os: macos-latest
+            ocaml-version: "4.10"
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set-up OCaml ${{ matrix.ocaml-version }}
         uses: ocaml/setup-ocaml@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
           - "4.14"
           - "5.2"
           - "ocaml-variants.5.3.0+trunk"
+        exclude:
+          - os: windows-latest
+            ocaml-version: "4.06"
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
         ocaml-version:
           - 4.06.x
           - 4.14.x
-          - 5.1.x
-          - ocaml-variants.5.2.0+trunk
+          - 5.2.x
+          - ocaml-variants.5.3.0+trunk
         exclude:
           - os: windows-latest
             ocaml-version: ocaml-variants.5.2.0+trunk


### PR DESCRIPTION
The switch to arm64 macOS by default macos-latest of course breaks our 4.06 check. This PR:
- Updates actions/checkout (trivial)
- Switches to setup-ocaml@v3, which gives us unified Windows testing, but means that 4.06 Windows testing is removed too (not really an issue - it's still being tested elsewhere)
- Uses the macos-13 image in order to test 4.06 on Intel hardware