### PR TITLE
Fix compilation of num on 4.x bytecode-only architectures

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -22,7 +22,7 @@ else
 NATIVE_COMPILER = true
 endif
 else
-# OCaml 4.x only set's NATIVE_COMPILER = false when --disable-native-compiler is
+# OCaml 4.x only sets NATIVE_COMPILER = false when --disable-native-compiler is
 # given explicitly. Legacy architectures not supported by the native compiler
 # then end up with NATIVE_COMPILER=true and ARCH=none
 ifeq "$(ARCH)" "none"

--- a/Makefile.common
+++ b/Makefile.common
@@ -17,8 +17,17 @@ ifeq "$(NATIVE_COMPILER)" ""
 # $(NATIVE_COMPILER) was added in 4.09: use $(ARCH) for 4.06-4.08
 ifeq "$(ARCH)" "none"
 NATIVE_COMPILER = false
+NATDYNLINK = false
 else
 NATIVE_COMPILER = true
+endif
+else
+# OCaml 4.x only set's NATIVE_COMPILER = false when --disable-native-compiler is
+# given explicitly. Legacy architectures not supported by the native compiler
+# then end up with NATIVE_COMPILER=true and ARCH=none
+ifeq "$(ARCH)" "none"
+NATIVE_COMPILER = false
+NATDYNLINK = false
 endif
 endif
 


### PR DESCRIPTION
Comment in the code explains the underlying slightly weird issue. 5.x behaves more logically with these variables - I happened to stumble across this oddity with some relocatable stuff.

As it happens, fixes #39 - but it would be better if `--disable-native-compiler` were instead being specified [here](https://github.com/barracuda156/powerpc-ports/blob/d06e1573f3a70f7270c764b86f502ab17352838a/lang/ocaml/Portfile#L69).